### PR TITLE
FTW!

### DIFF
--- a/pkgs/development/compilers/gerbil/ftw.nix
+++ b/pkgs/development/compilers/gerbil/ftw.nix
@@ -1,0 +1,27 @@
+{ lib, fetchFromGitHub, gerbilPackages, ... }:
+
+{
+  pname = "ftw";
+  version = "unstable-2021-06-30";
+  git-version = "master";
+  softwareName = "FTW: For The Web!";
+  gerbil-package = "drewc/smug";
+
+  gerbilInputs = with gerbilPackages; [ gerbil-utils ];
+
+  pre-src = {
+    fun = fetchFromGitHub;
+    owner = "drewc";
+    repo = "ftw";
+    rev = "22fb47f3832a254c459a8294a43c3a6fae7687e0";
+    sha256 = "1yibpwk3556zkd55yp0iv4sh4yk22dglhgaxj4b4r9q8i0a2fhdm";
+  };
+
+  meta = with lib; {
+    description = "Simple web handlers for Gerbil Scheme";
+    homepage    = "https://github.com/drewc/ftw";
+    license     = licenses.mit;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ fare ];
+  };
+}

--- a/pkgs/development/compilers/gerbil/gerbil-support.nix
+++ b/pkgs/development/compilers/gerbil/gerbil-support.nix
@@ -7,7 +7,7 @@ selfPop (gerbil-support: with gerbil-support; {
   inherit POP;
 
   prePackages-unstable =
-    let pks = [ ./gerbil-libp2p.nix ./smug-gerbil.nix
+    let pks = [ ./gerbil-libp2p.nix ./smug-gerbil.nix ./ftw.nix
                 ./gerbil-utils.nix ./gerbil-crypto.nix ./gerbil-poo.nix
                 ./gerbil-persist.nix ./gerbil-ethereum.nix ./glow-lang.nix ];
         call = pkg: callPackage pkg (unpop prePackage-defaults);


### PR DESCRIPTION
Add `drewc/ftw` (For The Web!) to `gerbilPackages-unstable`. Needed for recent `glow-lang` work.