### PR TITLE
disable stackprotector on aarch64-darwin for now

### DIFF
--- a/pkgs/development/compilers/gambit/bootstrap.nix
+++ b/pkgs/development/compilers/gambit/bootstrap.nix
@@ -15,6 +15,16 @@ gccStdenv.mkDerivation {
 
   buildInputs = [ autoconf ];
 
+  # disable stackprotector on aarch64-darwin for now
+  #
+  # build error:
+  #
+  # /private/tmp/nix-build-gambit-bootstrap-unstable-unstable-2021-12-14.drv-0/ccM8ZDYN.s:174:15: error: index must be an integer in range [-256, 255].
+  #         ldr     x0, [x0, ___stack_chk_guard];momd
+  #                          ^
+  #
+  hardeningDisable = lib.optionals (gccStdenv.isAarch64 && gccStdenv.isDarwin) [ "stackprotector" ];
+
   configurePhase = ''
     export CC=${gcc}/bin/gcc CXX=${gcc}/bin/g++ \
            CPP=${gcc}/bin/cpp CXXCPP=${gcc}/bin/cpp LD=${gcc}/bin/ld \

--- a/pkgs/development/compilers/gambit/build.nix
+++ b/pkgs/development/compilers/gambit/build.nix
@@ -36,6 +36,16 @@ gccStdenv.mkDerivation rec {
   # Or wrap relevant programs to add a suitable PATH ?
   #runtimeDeps = [ gnused gnugrep ];
 
+  # disable stackprotector on aarch64-darwin for now
+  #
+  # build error:
+  #
+  # /private/tmp/nix-build-gambit-bootstrap-unstable-unstable-2021-12-14.drv-0/ccM8ZDYN.s:174:15: error: index must be an integer in range [-256, 255].
+  #         ldr     x0, [x0, ___stack_chk_guard];momd
+  #                          ^
+  #
+  hardeningDisable = lib.optionals (gccStdenv.isAarch64 && gccStdenv.isDarwin) [ "stackprotector" ];
+
   configureFlags = [
     "--enable-targets=${gambit-params.targets}"
     "--enable-single-host"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Getting rid of errors like 
```
/private/tmp/nix-build-gambit-bootstrap-unstable-unstable-2021-12-14.drv-0/ccM8ZDYN.s:174:15: error: index must be an integer in range [-256, 255].
        ldr     x0, [x0, ___stack_chk_guard];momd
                         ^
```
that happen on the new Apple M1 chip without this change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
